### PR TITLE
fix(browser-tools): reduce browser tool latency across 5 bottlenecks

### DIFF
--- a/.hx/workflows/bugfixes/260406-10-starting-workflow-bug-fix-phases-triage/STATE.json
+++ b/.hx/workflows/bugfixes/260406-10-starting-workflow-bug-fix-phases-triage/STATE.json
@@ -1,0 +1,32 @@
+{
+  "template": "bugfix",
+  "templateName": "Bug Fix",
+  "description": "Starting workflow: Bug Fix Phases: triage → fix → verify → ship Artifacts: .hx/workflows/bugfixes/260406-3-test-branch-isimlendirme-denemesi Branch: hx/bugfix/test-branch-isimlendirme-denemesi türkçe isimlendirdi.",
+  "branch": "hx/bugfix/starting-workflow-bug-fix-phases-triage",
+  "phases": [
+    {
+      "name": "triage",
+      "index": 0,
+      "status": "active"
+    },
+    {
+      "name": "fix",
+      "index": 1,
+      "status": "pending"
+    },
+    {
+      "name": "verify",
+      "index": 2,
+      "status": "pending"
+    },
+    {
+      "name": "ship",
+      "index": 3,
+      "status": "pending"
+    }
+  ],
+  "currentPhase": 0,
+  "startedAt": "2026-04-06T14:38:33.488Z",
+  "updatedAt": "2026-04-06T14:38:33.488Z",
+  "artifactDir": "/Users/beratcan/Desktop/GithubProjects/hx-ai/.hx/workflows/bugfixes/260406-10-starting-workflow-bug-fix-phases-triage"
+}

--- a/.hx/workflows/bugfixes/260406-11-bugfix-general/TRIAGE.md
+++ b/.hx/workflows/bugfixes/260406-11-bugfix-general/TRIAGE.md
@@ -1,0 +1,59 @@
+# Triage: Browser Tool Slowness
+
+## Bug Description
+Agent browser tool calls (browser_click, browser_type, browser_navigate, etc.) take excessively long, causing noticeable lag during UI verification workflows.
+
+## Root Causes
+
+### RC1: Hardcoded 300ms sleep in browser_navigate (navigation.ts:35)
+```ts
+await new Promise(resolve => setTimeout(resolve, 300));
+```
+A fixed 300ms delay after `networkidle` wait, on top of the adaptive settle that already handles DOM quiet detection. This is pure waste — settle already covers it.
+
+### RC2: networkidle timeout too high (navigation.ts:34,113,157,192)
+```ts
+await p.waitForLoadState("networkidle", { timeout: 5000 });
+```
+4 call sites in navigation.ts all use 5000ms timeout. Pages with analytics, WebSocket, SSE, or long-polling connections regularly hit this full 5s wait since networkidle requires zero in-flight requests for 500ms. Caught and ignored anyway (`catch(() => {})`), so the timeout just wastes time.
+
+### RC3: Redundant evaluate round-trips per action (interaction.ts)
+Every `browser_click` makes **4 separate `evaluate()` calls** before settle:
+1. `captureCompactPageState(before)` — 1 evaluate
+2. `captureClickTargetState(before)` — 1 evaluate  
+3. `captureCompactPageState(after)` — 1 evaluate
+4. `captureClickTargetState(after)` — 1 evaluate
+
+Before+after target state could be captured inside the respective compact state call, cutting 4 → 2 evaluates.
+
+### RC4: Settle polling thresholds are conservative (settle.ts:105-115)
+- `ZERO_MUTATION_THRESHOLD_MS = 60` — waits 60ms before even checking zero-mutation shortcut
+- `ZERO_MUTATION_QUIET_MS = 30` — then requires 30ms additional quiet
+- `baseQuietWindowMs = 100` — normal quiet window is 100ms
+- `pollMs = 40` — poll interval of 40ms
+
+Best-case settle: 40ms (first poll) + 60ms (threshold) + 30ms (quiet) = **130ms minimum**. For static pages where click doesn't cause any DOM changes, this is unnecessarily high.
+
+### RC5: sharp metadata read on every screenshot (capture.ts:171)
+```ts
+const meta = await sharp(buffer).metadata();
+```
+Even small screenshots (800×600) hit `sharp(buffer).metadata()` to check dimensions before deciding to skip resize. This is a CPU-bound operation that adds ~5-10ms per screenshot call.
+
+## Affected Files
+- `src/resources/extensions/browser-tools/tools/navigation.ts` — RC1, RC2
+- `src/resources/extensions/browser-tools/settle.ts` — RC4
+- `src/resources/extensions/browser-tools/capture.ts` — RC5
+- `src/resources/extensions/browser-tools/tools/interaction.ts` — RC3
+
+## Blast Radius
+All browser_* tool calls are affected. The fixes are purely performance — no behavior change for correct operations.
+
+## Proposed Fix (scoped to low-risk, high-impact)
+1. **Remove 300ms sleep** from browser_navigate (RC1) — zero risk
+2. **Reduce networkidle timeout** 5000ms → 2000ms (RC2) — already caught, non-fatal
+3. **Tighten settle thresholds** (RC4) — reduce zero-mutation path to ~60ms total
+4. **Skip sharp metadata for small buffers** (RC5) — use buffer byte size heuristic
+5. **Merge captureClickTargetState into captureCompactPageState** (RC3) — reduces evaluate round-trips
+
+Items 1-4 are safe, surgical. Item 5 is slightly more involved (refactor), but mechanically straightforward.

--- a/src/resources/extensions/browser-tools/capture.ts
+++ b/src/resources/extensions/browser-tools/capture.ts
@@ -54,11 +54,12 @@ export function getScreenshotQualityDefault(fallback: number): number {
 
 export async function captureCompactPageState(
 	p: Page,
-	options: { selectors?: string[]; includeBodyText?: boolean; target?: Page | Frame } = {},
+	options: { selectors?: string[]; includeBodyText?: boolean; target?: Page | Frame; clickTargetSelector?: string } = {},
 ): Promise<CompactPageState> {
 	const selectors = Array.from(new Set((options.selectors ?? []).filter(Boolean)));
+	const clickTargetSelector = options.clickTargetSelector ?? null;
 	const target = options.target ?? p;
-	const domState = await target.evaluate(({ selectors, includeBodyText }) => {
+	const domState = await target.evaluate(({ selectors, includeBodyText, clickTargetSelector }) => {
 		const selectorStates: Record<string, {
 			exists: boolean;
 			visible: boolean;
@@ -102,6 +103,33 @@ export async function captureCompactPageState(
 			};
 		}
 
+		// Click target state capture — done in same evaluate to save a round-trip
+		let clickTargetState: {
+			exists: boolean;
+			ariaExpanded: string | null;
+			ariaPressed: string | null;
+			ariaSelected: string | null;
+			open: boolean | null;
+		} | null = null;
+		if (clickTargetSelector) {
+			try {
+				const el = document.querySelector(clickTargetSelector) as HTMLElement | null;
+				if (!el) {
+					clickTargetState = { exists: false, ariaExpanded: null, ariaPressed: null, ariaSelected: null, open: null };
+				} else {
+					clickTargetState = {
+						exists: true,
+						ariaExpanded: el.getAttribute("aria-expanded"),
+						ariaPressed: el.getAttribute("aria-pressed"),
+						ariaSelected: el.getAttribute("aria-selected"),
+						open: el instanceof HTMLDialogElement ? el.open : el.getAttribute("open") !== null,
+					};
+				}
+			} catch {
+				clickTargetState = { exists: false, ariaExpanded: null, ariaPressed: null, ariaSelected: null, open: null };
+			}
+		}
+
 		const focused = document.activeElement as HTMLElement | null;
 		const focusedDesc = focused && focused !== document.body && focused !== document.documentElement
 			? `${focused.tagName.toLowerCase()}${focused.id ? '#' + focused.id : ''}${focused.getAttribute('aria-label') ? ' "' + focused.getAttribute('aria-label') + '"' : ''}`
@@ -129,10 +157,15 @@ export async function captureCompactPageState(
 				title: dialogTitle,
 			},
 			selectorStates,
+			clickTargetState: clickTargetState ?? undefined,
 		};
-	}, { selectors, includeBodyText: options.includeBodyText === true });
+	}, { selectors, includeBodyText: options.includeBodyText === true, clickTargetSelector });
 	// URL and title always come from the Page, not the frame
-	return { ...domState, url: p.url(), title: await p.title() };
+	const result: CompactPageState = { ...domState, url: p.url(), title: await p.title() };
+	if (domState.clickTargetState) {
+		result.clickTargetState = domState.clickTargetState;
+	}
+	return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -168,6 +201,14 @@ export async function constrainScreenshot(
 	mimeType: string,
 	quality: number,
 ): Promise<Buffer> {
+	// Fast path for PNG: IHDR chunk contains width/height at fixed offsets (bytes 16-23).
+	// This avoids a full sharp metadata decode for images already within limits.
+	if (mimeType === "image/png" && buffer.length >= 24) {
+		const w = buffer.readUInt32BE(16);
+		const h = buffer.readUInt32BE(20);
+		if (w <= MAX_SCREENSHOT_WIDTH && h <= MAX_SCREENSHOT_HEIGHT) return buffer;
+	}
+
 	const meta = await sharp(buffer).metadata();
 	const width = meta.width;
 	const height = meta.height;

--- a/src/resources/extensions/browser-tools/settle.ts
+++ b/src/resources/extensions/browser-tools/settle.ts
@@ -102,17 +102,17 @@ async function readSettleState(
 // ---------------------------------------------------------------------------
 
 /** Threshold (ms) after which zero mutations triggers a shortened quiet window. */
-const ZERO_MUTATION_THRESHOLD_MS = 60;
+const ZERO_MUTATION_THRESHOLD_MS = 30;
 /** Shortened quiet window when no mutations have been observed. */
-const ZERO_MUTATION_QUIET_MS = 30;
+const ZERO_MUTATION_QUIET_MS = 15;
 
 export async function settleAfterActionAdaptive(
 	p: Page,
 	opts: AdaptiveSettleOptions = {},
 ): Promise<AdaptiveSettleDetails> {
-	const timeoutMs = Math.max(150, opts.timeoutMs ?? 500);
-	const pollMs = Math.min(100, Math.max(20, opts.pollMs ?? 40));
-	const baseQuietWindowMs = Math.max(60, opts.quietWindowMs ?? 100);
+	const timeoutMs = Math.max(150, opts.timeoutMs ?? 400);
+	const pollMs = Math.min(100, Math.max(15, opts.pollMs ?? 30));
+	const baseQuietWindowMs = Math.max(40, opts.quietWindowMs ?? 80);
 	const checkFocus = opts.checkFocusStability ?? false;
 
 	const startedAt = Date.now();

--- a/src/resources/extensions/browser-tools/state.ts
+++ b/src/resources/extensions/browser-tools/state.ts
@@ -113,6 +113,8 @@ export interface CompactPageState {
 		title: string;
 	};
 	selectorStates: Record<string, CompactSelectorState>;
+	/** Click target state — only present when clickTargetSelector was provided. */
+	clickTargetState?: ClickTargetStateSnapshot;
 }
 
 export interface TraceSessionState {
@@ -335,7 +337,7 @@ export interface ToolDeps {
 	// Capture & summary
 	captureCompactPageState: (
 		p: Page,
-		options?: { selectors?: string[]; includeBodyText?: boolean; target?: Page | Frame }
+		options?: { selectors?: string[]; includeBodyText?: boolean; target?: Page | Frame; clickTargetSelector?: string }
 	) => Promise<CompactPageState>;
 	postActionSummary: (p: Page, target?: Page | Frame) => Promise<string>;
 	formatCompactStateSummary: (state: CompactPageState) => string;

--- a/src/resources/extensions/browser-tools/tools/interaction.ts
+++ b/src/resources/extensions/browser-tools/tools/interaction.ts
@@ -34,13 +34,11 @@ export function registerInteractionTools(pi: ExtensionAPI, deps: ToolDeps): void
 			try {
 				const { page: p } = await deps.ensureBrowser();
 				const target = deps.getActiveTarget();
-				beforeState = await deps.captureCompactPageState(p, { selectors: params.selector ? [params.selector] : [], includeBodyText: true, target });
+				beforeState = await deps.captureCompactPageState(p, { selectors: params.selector ? [params.selector] : [], includeBodyText: true, target, clickTargetSelector: params.selector });
 				actionId = deps.beginTrackedAction("browser_click", params, beforeState.url).id;
 				const beforeUrl = p.url();
 				const beforeHash = deps.getUrlHash(beforeUrl);
-				const beforeTargetState = params.selector
-					? await deps.captureClickTargetState(target, params.selector)
-					: null;
+				const beforeTargetState = beforeState.clickTargetState ?? null;
 
 				if (params.selector) {
 					try {
@@ -84,12 +82,10 @@ export function registerInteractionTools(pi: ExtensionAPI, deps: ToolDeps): void
 
 				const settle = await deps.settleAfterActionAdaptive(p);
 
-				const afterState = await deps.captureCompactPageState(p, { selectors: params.selector ? [params.selector] : [], includeBodyText: true, target });
+				const afterState = await deps.captureCompactPageState(p, { selectors: params.selector ? [params.selector] : [], includeBodyText: true, target, clickTargetSelector: params.selector });
 				const url = afterState.url;
 				const hash = deps.getUrlHash(url);
-				const afterTargetState = params.selector
-					? await deps.captureClickTargetState(target, params.selector)
-					: null;
+				const afterTargetState = afterState.clickTargetState ?? null;
 				const targetStateChanged = !!beforeTargetState && !!afterTargetState && (
 					beforeTargetState.exists !== afterTargetState.exists ||
 					beforeTargetState.ariaExpanded !== afterTargetState.ariaExpanded ||

--- a/src/resources/extensions/browser-tools/tools/navigation.ts
+++ b/src/resources/extensions/browser-tools/tools/navigation.ts
@@ -31,8 +31,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 				beforeState = await deps.captureCompactPageState(p, { includeBodyText: true });
 				actionId = deps.beginTrackedAction("browser_navigate", params, beforeState.url).id;
 				await p.goto(params.url, { waitUntil: "domcontentloaded", timeout: 30000 });
-				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
-				await new Promise(resolve => setTimeout(resolve, 300));
+				await p.waitForLoadState("networkidle", { timeout: 2000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 
 				const title = await p.title();
 				const url = p.url();
@@ -110,7 +109,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 					};
 				}
 
-				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
+				await p.waitForLoadState("networkidle", { timeout: 2000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 
 				const title = await p.title();
 				const url = p.url();
@@ -154,7 +153,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 					};
 				}
 
-				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
+				await p.waitForLoadState("networkidle", { timeout: 2000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 
 				const title = await p.title();
 				const url = p.url();
@@ -189,7 +188,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 			try {
 				const { page: p } = await deps.ensureBrowser();
 				await p.reload({ waitUntil: "domcontentloaded", timeout: 30000 });
-				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
+				await p.waitForLoadState("networkidle", { timeout: 2000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 
 				const title = await p.title();
 				const url = p.url();


### PR DESCRIPTION
## Problem

Agent browser tool calls take excessively long, causing noticeable lag during UI verification workflows.

## Root Causes & Fixes

| # | Root Cause | Fix | Impact |
|---|---|---|---|
| RC1 | Hardcoded 300ms sleep in browser_navigate | Removed — settle handles DOM quiet | -300ms/navigate |
| RC2 | networkidle timeout 5000ms ×4 sites | Reduced to 2000ms (non-fatal catch) | -3s on long-poll pages |
| RC3 | 4 evaluate round-trips per browser_click | Merged into single capture (4→2) | -40~80ms/click |
| RC4 | Conservative settle thresholds | Tightened polling + quiet windows | -50~100ms/action |
| RC5 | sharp.metadata() on every screenshot | PNG IHDR header fast-path | -5~10ms/small png |

## Estimated Impact
- Typical 10-action workflow: **3-15s faster**
- Long-polling pages: **30s+ faster**

## Verification
TypeScript ✅ | Tests ✅ 110/110 | Build ✅